### PR TITLE
Fixing initial Solr package

### DIFF
--- a/solr-splainer-plugin/pom.xml
+++ b/solr-splainer-plugin/pom.xml
@@ -70,7 +70,32 @@
             </resource>
           </resources>
         </configuration>
-      </plugin>    
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+            <execution>
+                <configuration>
+                    <executable>python</executable>
+                    <workingDirectory>.</workingDirectory>
+                    <arguments>
+                        <argument>release.py</argument>
+                        <argument>${artifactId}</argument>
+                        <argument>${version}</argument>
+                    </arguments>    
+
+                </configuration>
+                <id>python-build</id>
+                <phase>package</phase>
+                <goals>
+                    <goal>exec</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/solr-splainer-plugin/release.py
+++ b/solr-splainer-plugin/release.py
@@ -1,0 +1,59 @@
+
+import sys
+import os
+import json
+import datetime
+
+artifact_name = sys.argv[1]
+version = sys.argv[2]
+
+os.popen("cp target/" + artifact_name + "-" + version + ".jar repo/.")
+
+if os.getenv("SOLR_PACKAGE_SIGNING_PRIVATE_KEY_PATH") == None:
+    raise Exception("Please add an environment variable SOLR_PACKAGE_SIGNING_PRIVATE_KEY_PATH to point to your private key (.pem) file used for signing the package artifacts.")
+    sys.exit(1)
+
+private_key_file = os.getenv("SOLR_PACKAGE_SIGNING_PRIVATE_KEY_PATH")
+
+if (os.path.isfile(private_key_file) == False):
+    raise Exception("SOLR_PACKAGE_SIGNING_PRIVATE_KEY_PATH points to non-existent private key (.pem) file used for signing the package artifacts.")
+    sys.exit(1)
+
+# Generate a publickey.der file
+os.popen("openssl rsa -in "+private_key_file+" -outform DER -pubout -out repo/publickey.der")
+
+# Sign the artifact using the private key
+with os.popen("openssl dgst -sha1 -sign "+private_key_file+" repo/"+artifact_name+"-"+version+".jar | openssl enc -base64") as f:
+    signature = "".join(f.readlines()).replace("\n", "")
+print("Signed artifacts with: " + signature)
+
+# Update the repo/repository.json with the released artifact
+repository = json.load(open("repo/repository.json"))
+
+# FORMAT:
+#        {
+#          "version": "1.0.0",
+#          "date": "2019-12-13",
+#          "artifacts": [
+#            {
+#              "url": "question-answering-1.0.jar",
+#              "sig": "Hau46QF4424qUDSMwRYa/sO/L4Hfbdr6jLQDEsbJpXJdR6jPmd9v92mAU8wSMO/riVk/Zc4oovCCu2PRWnz7sA=="
+#            }
+#          ]
+#        }
+
+release = {}
+release["version"] = version
+release["date"] = str(datetime.date.today())
+release["artifacts"] = [{"url": artifact_name + "-" + version + ".jar", "sig": signature}]
+
+retainedReleases = []
+for i in range(len(repository[0]["versions"])):
+    if (repository[0]["versions"][i]["version"] != version):
+        retainedReleases.append(repository[0]["versions"][i])
+retainedReleases.append(release)
+repository[0]["versions"] = retainedReleases
+
+json.dump(repository, open('repo/repository.json', 'w'), indent=2)
+
+print(repository)

--- a/solr-splainer-plugin/repo/repository.json
+++ b/solr-splainer-plugin/repo/repository.json
@@ -1,0 +1,11 @@
+[
+    {
+      "name": "solr-splainer",
+      "description": "Splainer for Solr",
+      "versions": [
+        
+      ]
+    }
+  ]
+  
+  

--- a/solr-splainer-plugin/src/main/resources/manifest.json
+++ b/solr-splainer-plugin/src/main/resources/manifest.json
@@ -17,7 +17,7 @@
         }
       },
       "verify-command": {
-        "path": "/api/cluster/zk/data/clusterprops.json",
+        "path": "/api/cluster/plugin",
         "method": "GET",
         "condition": "$['plugin'].['${package-name}:${plugin-name}'].['version']",
         "expected": "${package-version}"


### PR DESCRIPTION
Steps to execute:

1. Export the private key:

```export SOLR_PACKAGE_SIGNING_PRIVATE_KEY_PATH=~/.solr-private-key.pem```

2. Build the package:

```mvn package```

3. Now, host the solr-splainer-plugin/repo folder:

```cd solr-splainer-plugin; python2 -m SimpleHTTPServer```

4. In a Run Solr and install the package:

    tar -xf solr-9.3.0.tgz; cd solr-9.3.0/
    bin/solr -c -Denable.packages=true;
    bin/solr package add-repo splainer-repo "http://localhost:8000/repo/"; 
    bin/solr package list-available; 
    bin/solr package install solr-splainer; 
    bin/solr package deploy solr-splainer -y -cluster

5. Navigate to http://localhost:8983/v2/splainer on the browser.